### PR TITLE
Fix: VS Code-based editors compatibility (Cursor, Windsurf, VSCodium, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v0.0.11 - 2025-01-27
+
+- fix: Make chat participant registration conditional for VS Code alternatives compatibility
+- fix: Remove hard dependency on github.copilot-chat extension
+- fix: Add graceful fallback when chat APIs are not available (Cursor, VSCodium, etc.)
+- chore: Chat features now only enabled when GitHub Copilot is available
+
 ## v0.0.10 - 2025-07-02
 
 - chore: PG-Meta API update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v0.0.11 - 2025-01-27
+## v0.0.11 - 2025-07-22
 
 - fix: Make chat participant registration conditional for VS Code alternatives compatibility
 - fix: Remove hard dependency on github.copilot-chat extension

--- a/package.json
+++ b/package.json
@@ -63,9 +63,7 @@
     "vscode-test": "^1.5.0"
   },
   "activationEvents": [],
-  "extensionDependencies": [
-    "github.copilot-chat"
-  ],
+  "extensionDependencies": [],
   "contributes": {
     "viewsContainers": {
       "activitybar": [
@@ -99,6 +97,7 @@
         "id": "supabase.clippy",
         "name": "supabase",
         "description": "Ask Supabase Clippy about your database.",
+        "when": "extension.github.copilot-chat",
         "commands": [
           {
             "name": "show",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-supabase-extension",
   "displayName": "Supabase",
   "description": "Supabase Extension for VS Code and GitHub Copilot.",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "engines": {
     "vscode": "^1.90.0"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Compatibility fix for VS Code-based editors and alternatives that don't support experimental chat APIs

## What is the current behavior?

The extension fails to load in VS Code-based editors like Cursor, Windsurf, VSCodium, and other alternatives with the error:
```
This extension is using the API proposals 'defaultChatParticipant' and 'chatParticipantPrivate' that are not compatible with the current version of VS Code.
```

This happens because the extension has a hard dependency on `github.copilot-chat` and unconditionally registers chat participants using experimental APIs that are only available in official VS Code with GitHub Copilot installed.

**Affected editors:**
- Cursor (VS Code fork with AI features)
- Windsurf (VS Code fork by Codeium)  
- VSCodium (Open-source VS Code without Microsoft telemetry)
- Other VS Code forks and alternatives

Related to issue #36 - Request to publish on Open VSX Marketplace for broader compatibility.

## What is the new behavior?

- Chat participant registration is now conditional and only occurs when `vscode.chat` API is available
- Removed hard dependency on `github.copilot-chat` from `extensionDependencies`
- Added graceful fallback when chat APIs are not available
- All database functionality (tables, migrations, functions, etc.) works normally across all VS Code-based editors
- Chat features are only enabled when GitHub Copilot is present

The extension now works seamlessly across the entire VS Code ecosystem while maintaining full functionality in official VS Code with GitHub Copilot.

## Additional context

This fix enables the extension to be published on Open VSX Marketplace, making it accessible to users of open-source VS Code alternatives. The core database management features remain fully functional across all platforms, with chat features being an optional enhancement when available.