### PR TITLE
fix: storage listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.0.13 - 2026-01-28
+
+- fix: Storage buckets and objects listing 
+
 ## v0.0.12 - 2025-12-15
 
 - fix: chat participant with Supabase enabled

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-supabase-extension",
   "displayName": "Supabase",
   "description": "Supabase Extension for VS Code and GitHub Copilot.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "engines": {
     "vscode": "^1.90.0"
   },

--- a/src/features/database/classes/supabase-api.ts
+++ b/src/features/database/classes/supabase-api.ts
@@ -130,7 +130,7 @@ export class SupabaseApi {
   }
 
   async getBucketList(item: string): Promise<BucketItem[]> {
-    const endpoint = `${this.baseUrl}${Endpoint.BUCKETS}/${item}/objects/list`;
+    const endpoint = `${this.baseUrl}:${Ports.PG_META}${Endpoint.BUCKETS}/${item}/objects/list`;
     const [err, res] = await to(axios.post(endpoint));
 
     if (err) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently if you have any buckets in storage and connect the following alert appears:

<img width="458" height="48" alt="Screenshot 2026-01-28 at 14 49 56" src="https://github.com/user-attachments/assets/29b897de-8e15-40df-9e7d-4f4305252ca0" />

This change now lists out your buckets and shows you a list of objects.

